### PR TITLE
update react and fix deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ var Header = React.createClass({
   }
 });
 
-React.renderComponent(<Header>Hello</Header>, document.body);
+React.render(<Header>Hello</Header>, document.body);
 ```
 
-Or you can wrap it at the `renderComponent` call.
+Or you can wrap it at the `render` call.
 
 ```html
-React.renderComponent(
+React.render(
   <Frame>
     <Header>Hello</Header>
   </Frame>,

--- a/index.js
+++ b/index.js
@@ -3,10 +3,10 @@ var React = require('react');
 var Frame = React.createClass({
   propTypes: {
     style: React.PropTypes.object,
-    head:  React.PropTypes.renderable
+    head:  React.PropTypes.node
   },
   render: function() {
-    return this.transferPropsTo(React.DOM.iframe());
+    return React.createElement('iframe', this.props);
   },
   componentDidMount: function() {
     this.renderFrameContents();
@@ -14,14 +14,15 @@ var Frame = React.createClass({
   renderFrameContents: function() {
     var doc = this.getDOMNode().contentDocument;
     if(doc && doc.readyState === 'complete') {
-      var contents = React.DOM.div(null,
+      var contents = React.createElement('div',
+        undefined,
         this.props.head,
         this.props.children
       );
 
-      React.renderComponent(contents, doc.body);
+      React.render(contents, doc.body);
     } else {
-       setTimeout(this.renderFrameContents, 0);
+      setTimeout(this.renderFrameContents, 0);
     }
   },
   componentDidUpdate: function() {
@@ -32,5 +33,5 @@ var Frame = React.createClass({
   }
 });
 
-module.exports = Frame;
 
+module.exports = Frame;

--- a/package.json
+++ b/package.json
@@ -23,18 +23,18 @@
   },
   "homepage": "https://github.com/ryanseddon/react-frame-component",
   "devDependencies": {
+    "browserify": "^4.1.11",
+    "es5-shim": "^3.3.0",
     "gulp": "^3.6.2",
-    "karma": "^0.12.16",
     "gulp-karma": "0.0.4",
+    "karma": "^0.12.16",
     "karma-jasmine": "^0.1.5",
     "karma-phantomjs-launcher": "^0.1.4",
-    "es5-shim": "^3.3.0",
-    "browserify": "^4.1.11",
-    "react": ">=0.11.1",
+    "react": ">=0.12.1",
     "reactify": "^0.13.1",
     "vinyl-source-stream": "^0.1.1"
   },
   "peerDependencies": {
-    "react": ">=0.11.1"
+    "react": ">=0.12.1"
   }
 }

--- a/test/Frame_spec.js
+++ b/test/Frame_spec.js
@@ -32,7 +32,7 @@ describe("Frame test",function(){
 
   it("should create an iFrame with a <link> tag inside", function () {
     div = document.body.appendChild(document.createElement('div'));
-    var frame = React.renderComponent(<Frame head={
+    var frame = React.render(<Frame head={
           <link href='styles.css' />
         } />, div),
         body = frame.getDOMNode().contentDocument.body;
@@ -43,7 +43,7 @@ describe("Frame test",function(){
 
   it("should create an iFrame with a <script> and insert children", function () {
     div = document.body.appendChild(document.createElement('div'));
-    var frame = React.renderComponent(<Frame head={
+    var frame = React.render(<Frame head={
           <script src="foo.js"></script>
         }>
           <h1>Hello</h1>
@@ -59,7 +59,7 @@ describe("Frame test",function(){
 
   it("should create an iFrame with multiple <link> and <script> tags inside", function () {
     div = document.body.appendChild(document.createElement('div'));
-    var frame = React.renderComponent(<Frame head={[
+    var frame = React.render(<Frame head={[
           <link key='styles' href='styles.css' />,
           <link key='foo' href='foo.css' />,
           <script key='bar' src='bar.js' />
@@ -72,7 +72,7 @@ describe("Frame test",function(){
 
   it("should encapsulate styles and not effect elements outside", function () {
     div = document.body.appendChild(document.createElement('div'));
-    var component = React.renderComponent(<div>
+    var component = React.render(<div>
           <p>Some text</p>
           <Frame head={
             <style>{'*{color:red}'}</style>


### PR DESCRIPTION
* Replace React.PropTypes.renderable with React.PropTypes.node
* Use React.createElement (fixes transferPropsTo warning, and React.DOM.iframe warning)
* Use React.render
* Update peerDependencies to work any version less than 1

fixes #8