### PR TITLE
Don't render the children on initial render.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,10 @@ var Frame = React.createClass({
     head:  React.PropTypes.node
   },
   render: function() {
-    return React.createElement('iframe', this.props);
+    return React.createElement('iframe', {
+      style: this.props.style,
+      head: this.props.head
+    });
   },
   componentDidMount: function() {
     this.renderFrameContents();
@@ -29,7 +32,7 @@ var Frame = React.createClass({
     this.renderFrameContents();
   },
   componentWillUnmount: function() {
-    React.unmountComponentAtNode(this.getDOMNode().contentDocument.body);
+    React.unmountComponentAtNode(React.findDOMNode(this).contentDocument.body);
   }
 });
 


### PR DESCRIPTION
When the Frame component is rendered, do not include this.props.children on the iframe's props. The DOM of the iframe is not ready at that point, so the children will be rendered as detached from the DOM tree.

This will trigger issues such as "Invariant Violation: findComponentRoot(..., .0.0): Unable to find element" when React.findDOMNode(this) is called inside componentDidMount().

The children should only be rendered when the the iframe is ready, and within Frame.renderFrameContents.