### PR TITLE
Add initialSrc prop

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,12 +3,14 @@ var React = require('react');
 var Frame = React.createClass({
   propTypes: {
     style: React.PropTypes.object,
-    head:  React.PropTypes.node
+    head:  React.PropTypes.node,
+    initialSrc: React.PropTypes.string
   },
   render: function() {
     return React.createElement('iframe', {
       style: this.props.style,
-      head: this.props.head
+      head: this.props.head,
+      src: this.props.initialSrc
     });
   },
   componentDidMount: function() {


### PR DESCRIPTION
Hi, thanks for this component!

I was having some weird browser issues and it turned out that was due to a missing doctype on the IFrame document. Here's one way we could allow the user to set a doctype:

    <Frame initialSrc="javascript:'<!DOCTYPE html><html><body></body></html>'" />

If this is the only valid use case for `initialSrc` it might of course be better to have a `props.doctype` instead and construct the IFrame `src` attribute from that.

(Probably related to #4 although I don't pretend to understand everything from that discussion.)