### PR TITLE
Remove children props on initial render

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var assign = require('react/lib/Object.assign');
 
 var Frame = React.createClass({
   propTypes: {
@@ -6,7 +7,8 @@ var Frame = React.createClass({
     head:  React.PropTypes.node
   },
   render: function() {
-    return React.createElement('iframe', this.props);
+    // The iframe isn't ready so we drop children from props here
+    return React.createElement('iframe', assign({}, this.props, {children: undefined}));
   },
   componentDidMount: function() {
     this.renderFrameContents();

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var React = require('react');
-var assign = require('react/lib/Object.assign');
+var assign = require('object-assign');
 
 var Frame = React.createClass({
   propTypes: {
@@ -7,7 +7,7 @@ var Frame = React.createClass({
     head:  React.PropTypes.node
   },
   render: function() {
-    // The iframe isn't ready so we drop children from props here
+    // The iframe isn't ready so we drop children from props here. #12, #17
     return React.createElement('iframe', assign({}, this.props, {children: undefined}));
   },
   componentDidMount: function() {

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
   },
   "peerDependencies": {
     "react": ">=0.13.0"
+  },
+  "dependencies": {
+    "object-assign": "^3.0.0"
   }
 }

--- a/test/Frame_spec.js
+++ b/test/Frame_spec.js
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 "use strict";
 
 var ReactTestUtils, div,
@@ -22,6 +20,21 @@ describe("Frame test",function(){
     var frame = ReactTestUtils.renderIntoDocument(<Frame />);
     expect(frame.props.children).toBeUndefined();
     expect(frame.getDOMNode().contentWindow).toBeDefined();
+  });
+
+  it("should not pass this.props.children in iframe render", function () {
+    spyOn(React, 'createElement').andCallThrough();
+    var frame = ReactTestUtils.renderIntoDocument(
+      <Frame className='foo'>
+        <div />
+      </Frame>
+    );
+
+    expect(React.createElement).toHaveBeenCalledWith('iframe',{
+      children: undefined,
+      className: 'foo'
+    });
+    expect(frame.props.children).toBeDefined();
   });
 
   it("should create an empty iFrame and apply inline styles", function () {


### PR DESCRIPTION
Delete `children` from `this.props` and store in state until `renderFrameContents` is called. Avoids double children render issues #12, #17.

cc @darbs, @daviferreira 