### PR TITLE
Tests passing for FF, Safarai, Chrome on SauceLabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 test/processed
 node_modules
+sauce.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # React &lt;Frame /> component
 
-[![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][depstat-image]][depstat-url]
+[![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][depstat-image]][depstat-url] 
+
+[![Sauce Test Status](https://saucelabs.com/browser-matrix/zealoushacker.svg)](https://saucelabs.com/u/zealoushacker)
 
 This component allows you to encapsulate your entire React application or per component in an iFrame.
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,38 @@
+var fs = require('fs');
 module.exports = function(config) {
-  config.set({
+  // Use ENV vars on Travis and sauce.json locally to get credentials
+  if (!process.env.SAUCE_USERNAME) {
+    if (!fs.existsSync('sauce.json')) {
+      console.log('Create a sauce.json with your credentials based on the sauce-sample.json file.');
+      process.exit(1);
+    } else {
+      process.env.SAUCE_USERNAME = require('./sauce').username;
+      process.env.SAUCE_ACCESS_KEY = require('./sauce').accessKey;
+    }
+  }
 
+  var customLaunchers = {
+    sl_chrome_mac: {
+      base: 'SauceLabs',
+      browserName: 'chrome',
+      platform: 'OS X 10.9',
+      version: '40.0'
+    },
+    sl_firefox_mac: {
+      base: 'SauceLabs',
+      browserName: 'firefox',
+      platform: 'OS X 10.9',
+      version: '35.0'
+    },
+    sl_safari: {
+      base: 'SauceLabs',
+      browserName: 'safari',
+      platform: 'OS X 10.9',
+      version: '7.0'
+    }
+  };
+
+  config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: '',
 
@@ -11,7 +43,7 @@ module.exports = function(config) {
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['progress'],
+    reporters: ['dots', 'saucelabs'],
 
     // web server port
     port: 9876,
@@ -26,12 +58,18 @@ module.exports = function(config) {
     // enable / disable watching file and executing tests whenever any file changes
     autoWatch: false,
 
-    // start these browsers
-    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['PhantomJS'],
-
-    // Continuous Integration mode
-    // if true, Karma captures browsers, runs the tests and exits
-    singleRun: true
+    sauceLabs: {
+      testName: 'react-frame-component cross-browser tests',
+      recordScreenshots: false
+    },
+    customLaunchers: customLaunchers,
+    browsers: Object.keys(customLaunchers),
+    singleRun: true,
+    // next settings based on:
+    // http://stackoverflow.com/questions/24093155/karma-sauce-launcher-disconnects-every-test-run-resulting-in-failed-runs-with-ie
+    browserDisconnectTimeout: 10000, // default 2000
+    browserDisconnectTolerance : 1, // default 0
+    browserNoActivityTimeout : 4*60*1000, //default 10000
+    captureTimeout : 4*60*1000 //default 60000
   });
 };

--- a/package.json
+++ b/package.json
@@ -28,8 +28,11 @@
     "gulp": "^3.6.2",
     "gulp-karma": "0.0.4",
     "karma": "^0.12.16",
+    "karma-chrome-launcher": "^0.2.0",
+    "karma-firefox-launcher": "^0.1.6",
     "karma-jasmine": "^0.1.5",
     "karma-phantomjs-launcher": "^0.1.4",
+    "karma-sauce-launcher": "^0.2.14",
     "react": ">=0.12.1",
     "reactify": "^1.1.0",
     "vinyl-source-stream": "^0.1.1"

--- a/sauce-sample.json
+++ b/sauce-sample.json
@@ -1,0 +1,4 @@
+{
+  "username": "yourSauceUsername",
+  "accessKey": "yourSauceAccessKey"
+}

--- a/test/Frame_spec.js
+++ b/test/Frame_spec.js
@@ -1,123 +1,166 @@
-"use strict";
+(function() {
+  "use strict";
 
-var ReactTestUtils, div,
-    React = require('react/addons'),
-    Frame = require('../index.js');
+  var ReactTestUtils, div,
+      React = require('react/addons'),
+      Frame = require('../index.js');
 
-describe("Frame test",function(){
-  beforeEach(function() {
-    ReactTestUtils = React.addons.TestUtils;
-  });
-
-  afterEach(function() {
-    if(div) {
-      div.parentNode.removeChild(div);
-      div = null;
-    }
-  });
-
-  it("should create an empty iFrame", function () {
-    var frame = ReactTestUtils.renderIntoDocument(<Frame />);
-    expect(frame.props.children).toBeUndefined();
-    expect(frame.getDOMNode().contentWindow).toBeDefined();
-  });
-
-  it("should not pass this.props.children in iframe render", function () {
-    spyOn(React, 'createElement').andCallThrough();
-    var frame = ReactTestUtils.renderIntoDocument(
-      <Frame className='foo'>
-        <div />
-      </Frame>
-    );
-
-    expect(React.createElement).toHaveBeenCalledWith('iframe',{
-      children: undefined,
-      className: 'foo'
+  describe("Frame test",function(){
+    beforeEach(function() {
+      ReactTestUtils = React.addons.TestUtils;
     });
-    expect(frame.props.children).toBeDefined();
+
+    afterEach(function() {
+      if(div) {
+        div.parentNode.removeChild(div);
+        div = null;
+      }
+    });
+
+    it("should create an empty iFrame", function () {
+      var frame = ReactTestUtils.renderIntoDocument(<Frame />);
+      expect(frame.props.children).toBeUndefined();
+      expect(frame.getDOMNode().contentWindow).toBeDefined();
+    });
+
+    it("should not pass this.props.children in iframe render", function () {
+      spyOn(React, 'createElement').andCallThrough();
+      var frame = ReactTestUtils.renderIntoDocument(
+        <Frame className='foo'>
+          <div />
+        </Frame>
+      );
+
+      expect(React.createElement).toHaveBeenCalledWith('iframe',{
+        children: undefined,
+        className: 'foo'
+      });
+      expect(frame.props.children).toBeDefined();
+    });
+
+    it("should create an empty iFrame and apply inline styles", function () {
+      var frame = ReactTestUtils.renderIntoDocument(<Frame style={{border:0}} />);
+      expect(frame.props.style).toEqual({border:0});
+      expect(frame.getDOMNode().style.border).toContain('0');
+    });
+
+    it("should pass along all props to underlying iFrame", function () {
+      var frame = ReactTestUtils.renderIntoDocument(
+        <Frame className="test-class-1 test-class-2"
+          frameBorder={0}
+          height="100%"
+          width="80%" />
+      );
+      var node = frame.getDOMNode();
+      expect(frame.props.className).toEqual('test-class-1 test-class-2');
+      expect(frame.props.frameBorder).toEqual(0);
+      expect(frame.props.height).toEqual('100%');
+      expect(frame.props.width).toEqual('80%');
+      expect(node.className).toEqual('test-class-1 test-class-2');
+      expect(node.getAttribute('frameBorder')).toEqual('0');
+      expect(node.getAttribute('height')).toEqual('100%');
+      expect(node.getAttribute('width')).toEqual('80%');
+    });
+
+    describe('cross-browser compatible', function() {
+      it("should create an iFrame with a <link> tag inside", function () {
+        div = document.body.appendChild(document.createElement('div'));
+        var frame = React.render(<Frame head={
+              <link href='styles.css' />
+            } />, div),
+            doc = frame.getDOMNode().contentDocument,
+            readyState = doc.readyState,
+            expectations = function() {
+              var body = frame.getDOMNode().contentDocument.body;
+
+              expect(body.querySelector('link')).toBeDefined();
+              expect(body.querySelector('link').href).toContain('styles.css');
+            };
+
+        if (readyState && readyState === 'complete') {
+          expectations();
+        } else {
+          setTimeout(expectations, 0);
+        } 
+      });
+
+      it("should create an iFrame with a <script> and insert children", function () {
+        div = document.body.appendChild(document.createElement('div'));
+        var frame = React.render(<Frame head={
+              <script src="foo.js"></script>
+            }>
+              <h1>Hello</h1>
+              <h2>World</h2>
+            </Frame>, div),
+            doc = frame.getDOMNode().contentDocument,
+            readyState = doc.readyState,
+            expectations = function() {
+              var body = doc.body;
+              expect(body.querySelector('script')).toBeDefined();
+              expect(body.querySelector('script').src).toContain('foo.js');
+              expect(frame.props.children).toBeDefined();
+              expect(body.querySelectorAll('h1,h2').length).toEqual(2);
+            };
+
+        if (readyState && readyState === 'complete') {
+          expectations();
+        } else {
+          setTimeout(expectations, 0);
+        } 
+      });
+
+      it("should create an iFrame with multiple <link> and <script> tags inside", function () {
+        div = document.body.appendChild(document.createElement('div'));
+        var frame = React.render(<Frame head={[
+              <link key='styles' href='styles.css' />,
+              <link key='foo' href='foo.css' />,
+              <script key='bar' src='bar.js' />
+            ]} />, div),
+            doc = frame.getDOMNode().contentDocument,
+            readyState = doc.readyState,
+            expectations = function() {
+              var body = doc.body;
+              expect(body.querySelectorAll('link').length).toEqual(2);
+              expect(body.querySelectorAll('script').length).toEqual(1);
+            };
+
+        if (readyState && readyState === 'complete') {
+          expectations();
+        } else {
+          setTimeout(expectations, 0);
+        } 
+      });
+
+      it("should encapsulate styles and not effect elements outside", function () {
+        div = document.body.appendChild(document.createElement('div'));
+        var component = React.render(<div>
+              <p>Some text</p>
+              <Frame head={
+                <style>{'*{color:red}'}</style>
+              }>
+                <p>Some text</p>
+              </Frame>
+            </div>, div),
+            frame = component.getDOMNode().querySelector('iframe'), 
+            doc = frame.contentDocument,
+            readyState = doc.readyState,
+            expectations = function() {
+              var body = doc.body,
+                elem = component.getDOMNode(),
+                body = doc.body,
+                getColour = function(elem) {
+                  return window.getComputedStyle(elem, null).getPropertyValue('color');
+                };
+              expect(getColour(elem.querySelector('p'))).toEqual('rgb(0, 0, 0)');
+              expect(getColour(body.querySelector('p'))).toEqual('rgb(255, 0, 0)');
+            }
+
+        if (readyState && readyState === 'complete') {
+          expectations();
+        } else {
+          setTimeout(expectations, 0);
+        } 
+      });
+    });
   });
-
-  it("should create an empty iFrame and apply inline styles", function () {
-    var frame = ReactTestUtils.renderIntoDocument(<Frame style={{border:0}} />);
-    expect(frame.props.style).toEqual({border:0});
-    expect(frame.getDOMNode().style.border).toContain('0');
-  });
-
-  it("should pass along all props to underlying iFrame", function () {
-    var frame = ReactTestUtils.renderIntoDocument(
-      <Frame className="test-class-1 test-class-2"
-        frameBorder={0}
-        height="100%"
-        width="80%" />
-    );
-    var node = frame.getDOMNode();
-    expect(frame.props.className).toEqual('test-class-1 test-class-2');
-    expect(frame.props.frameBorder).toEqual(0);
-    expect(frame.props.height).toEqual('100%');
-    expect(frame.props.width).toEqual('80%');
-    expect(node.className).toEqual('test-class-1 test-class-2');
-    expect(node.getAttribute('frameBorder')).toEqual('0');
-    expect(node.getAttribute('height')).toEqual('100%');
-    expect(node.getAttribute('width')).toEqual('80%');
-  });
-
-  it("should create an iFrame with a <link> tag inside", function () {
-    div = document.body.appendChild(document.createElement('div'));
-    var frame = React.render(<Frame head={
-          <link href='styles.css' />
-        } />, div),
-        body = frame.getDOMNode().contentDocument.body;
-
-    expect(body.querySelector('link')).toBeDefined();
-    expect(body.querySelector('link').href).toContain('styles.css');
-  });
-
-  it("should create an iFrame with a <script> and insert children", function () {
-    div = document.body.appendChild(document.createElement('div'));
-    var frame = React.render(<Frame head={
-          <script src="foo.js"></script>
-        }>
-          <h1>Hello</h1>
-          <h2>World</h2>
-        </Frame>, div),
-        body = frame.getDOMNode().contentDocument.body;
-
-    expect(body.querySelector('script')).toBeDefined();
-    expect(body.querySelector('script').src).toContain('foo.js');
-    expect(frame.props.children).toBeDefined();
-    expect(body.querySelectorAll('h1,h2').length).toEqual(2);
-  });
-
-  it("should create an iFrame with multiple <link> and <script> tags inside", function () {
-    div = document.body.appendChild(document.createElement('div'));
-    var frame = React.render(<Frame head={[
-          <link key='styles' href='styles.css' />,
-          <link key='foo' href='foo.css' />,
-          <script key='bar' src='bar.js' />
-        ]} />, div),
-        body = frame.getDOMNode().contentDocument.body;
-
-    expect(body.querySelectorAll('link').length).toEqual(2);
-    expect(body.querySelectorAll('script').length).toEqual(1);
-  });
-
-  it("should encapsulate styles and not effect elements outside", function () {
-    div = document.body.appendChild(document.createElement('div'));
-    var component = React.render(<div>
-          <p>Some text</p>
-          <Frame head={
-            <style>{'*{color:red}'}</style>
-          }>
-            <p>Some text</p>
-          </Frame>
-        </div>, div),
-        elem = component.getDOMNode(),
-        body = elem.querySelector('iframe').contentDocument.body,
-        getColour = function(elem) {
-          return window.getComputedStyle(elem, null).getPropertyValue('color');
-        }
-
-    expect(getColour(elem.querySelector('p'))).toEqual('rgb(0, 0, 0)');
-    expect(getColour(body.querySelector('p'))).toEqual('rgb(255, 0, 0)');
-  });
-});
+})();


### PR DESCRIPTION
@ryanseddon I've added the fixes to the test suite, based on your idea, which make the tests pass in FF, Chrome, and Safari, as evidenced by the passing tests on SauceLabs (currently configured under my account). Alas, the tests don't yet pass in IE, but I don't have enough time left that I've allocated to this to figure out why. 

See `customLaunchers` in `karma.conf.js` for details on which specific browsers I've configured.

Because you're the maintainer, if you'd like to go forward with SuaceLabs to show that this is cross-browser compatible, you'd need to change the Sauce Test Status indicator to have your username. Also, you'd want to configure Travis, by setting the appropriate ENV variables (`SAUCE_USERNAME` and `SAUCE_ACCESS_KEY`) in your travis ci configuration for this project, or alternatively, pass them via `.travis.yml` options, secured, of course. SauceLab's free to sign-up for an open source project, so it may be worthwhile. Thought I'd add it as a recommendation.

Let me know what you think.