### PR TITLE
Preserve iframe DOM between renders

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,10 @@ var Frame = React.createClass({
 
       // React warns when you render directly into the body since browser
       // extensions also inject into the body and can mess up React.
-      doc.body.innerHTML = '<div></div>';
+      if (!this._createdDiv) {
+        doc.body.innerHTML = '<div></div>';
+        this._createdDiv = true;
+      }
 
       swallowInvalidHeadWarning();
       ReactDOM.render(contents, doc.body.firstChild);

--- a/test/Frame_spec.js
+++ b/test/Frame_spec.js
@@ -118,4 +118,28 @@ describe("Frame test",function(){
     expect(getColour(elem.querySelector('p'))).toEqual('rgb(0, 0, 0)');
     expect(getColour(body.querySelector('p'))).toEqual('rgb(255, 0, 0)');
   });
+
+  it("should re-render inside the iframe correctly", function () {
+    div = document.body.appendChild(document.createElement('div'));
+
+    var component1 = ReactDOM.render(
+          <Frame>
+            <p>Test 1</p>
+          </Frame>
+        , div),
+        body1 = ReactDOM.findDOMNode(component1).contentDocument.body,
+        p1 = body1.querySelector('p');
+    expect(p1.textContent).toEqual('Test 1');
+    p1.setAttribute('data-test-value', 'set on dom')
+
+    var component2 = ReactDOM.render(
+          <Frame>
+            <p>Test 2</p>
+          </Frame>
+        , div),
+        body2 = ReactDOM.findDOMNode(component2).contentDocument.body,
+        p2 = body2.querySelector('p');
+    expect(p2.textContent).toEqual('Test 2');
+    expect(p2.getAttribute('data-test-value')).toEqual('set on dom');
+  });
 });

--- a/test/Frame_spec.js
+++ b/test/Frame_spec.js
@@ -129,6 +129,7 @@ describe("Frame test",function(){
         , div),
         body1 = ReactDOM.findDOMNode(component1).contentDocument.body,
         p1 = body1.querySelector('p');
+
     expect(p1.textContent).toEqual('Test 1');
     p1.setAttribute('data-test-value', 'set on dom')
 
@@ -139,6 +140,7 @@ describe("Frame test",function(){
         , div),
         body2 = ReactDOM.findDOMNode(component2).contentDocument.body,
         p2 = body2.querySelector('p');
+
     expect(p2.textContent).toEqual('Test 2');
     expect(p2.getAttribute('data-test-value')).toEqual('set on dom');
   });


### PR DESCRIPTION
Right now, the iframe DOM is wiped out every time the component is updated. Unless I'm missing something, this is unnecessary, and it causes problems for my use case. Would it be all right to only write the iframe's innerHTML on the first render, as this change implements? (Thanks!)