### PR TITLE
Use unstable_renderSubtreeIntoContainer to expose context, fixes #29

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,9 @@ var Frame = React.createClass({
       }
 
       swallowInvalidHeadWarning();
-      ReactDOM.render(contents, doc.body.firstChild);
+      // unstable_renderSubtreeIntoContainer allows us to pass this component as
+      // the parent, which exposes context to any child components.
+      ReactDOM.unstable_renderSubtreeIntoContainer(this, contents, doc.body.firstChild);
       resetWarnings();
     } else {
       setTimeout(this.renderFrameContents, 0);

--- a/test/Frame_spec.js
+++ b/test/Frame_spec.js
@@ -144,4 +144,48 @@ describe("Frame test",function(){
     expect(p2.textContent).toEqual('Test 2');
     expect(p2.getAttribute('data-test-value')).toEqual('set on dom');
   });
+
+  it("should pass context to components in the frame", function () {
+    div = document.body.appendChild(document.createElement('div'));
+
+    var Parent = React.createClass({
+      childContextTypes: { color: React.PropTypes.string },
+      getChildContext: function() {
+        return {color: 'purple'};
+      },
+      render: function() {
+        return (
+          <div>
+            {this.props.children}
+          </div>
+        )
+      }
+    });
+
+    var Child = React.createClass({
+      contextTypes: {
+        color: React.PropTypes.string
+      },
+      render: function() {
+        return (
+          <div>
+            {this.context.color}
+          </div>
+        )
+      }
+    });
+
+    var component = ReactDOM.render(
+      <Parent>
+        <Frame refs='frame'>
+          <Child/>
+        </Frame>
+      </Parent>
+    , div)
+
+    var frame = div.querySelector('iframe')
+
+    expect(div.innerHTML).toEqual('<div data-reactid=".e"><iframe data-reactid=".e.0"></iframe></div>')
+    expect(frame.contentDocument.body.innerHTML).toEqual('<div><div data-reactid=".f"><div data-reactid=".f.1">purple</div></div></div>')
+  });
 });

--- a/test/Frame_spec.js
+++ b/test/Frame_spec.js
@@ -158,7 +158,7 @@ describe("Frame test",function(){
           <div>
             {this.props.children}
           </div>
-        )
+        );
       }
     });
 
@@ -171,7 +171,7 @@ describe("Frame test",function(){
           <div>
             {this.context.color}
           </div>
-        )
+        );
       }
     });
 

--- a/test/Frame_spec.js
+++ b/test/Frame_spec.js
@@ -181,11 +181,11 @@ describe("Frame test",function(){
           <Child/>
         </Frame>
       </Parent>
-    , div)
+    , div);
 
-    var frame = div.querySelector('iframe')
+    var frame = div.querySelector('iframe');
 
-    expect(div.innerHTML).toEqual('<div data-reactid=".e"><iframe data-reactid=".e.0"></iframe></div>')
-    expect(frame.contentDocument.body.innerHTML).toEqual('<div><div data-reactid=".f"><div data-reactid=".f.1">purple</div></div></div>')
+    expect(frame).not.toBeNull();
+    expect(frame.contentDocument.body.innerHTML).toEqual('<div><div data-reactid=".f"><div data-reactid=".f.1">purple</div></div></div>');
   });
 });


### PR DESCRIPTION
This uses unstable_renderSubtreeIntoContainer instead of render. This allows you
to pass a parent component and exposes the context of the parent to child
components.