### PR TITLE
Add support for setting initial content of the frame,  fixes #15

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ React.render(
 );
 ```
 
+#####Props:
+
+######head
+`head:  React.PropTypes.node`
+
+The `head` prop is a dom node that gets inserted before the children of the frame. Note that this is injected into the body of frame (see the blog post for why). This has the benefit of being able to update and works for stylesheets.
+
+######initialContent
+`initialContent:  React.PropTypes.string`
+
+Defaults to `'<html><head></head><body><div></div></body></html>'`
+
+The `initialContent` props is the initial html injected into frame. It is only injected once, but allows you to insert any html into the frame (e.g. a head tag, script tags, etc). Note that it does *not* update if you change the prop. Also at least one div is required in the body of the html, which we use to render the react dom into.
+
 ## More info
 
 I wrote a [blog post] [blog-url] about building this component.

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ var Frame = React.createClass({
       swallowInvalidHeadWarning();
       // unstable_renderSubtreeIntoContainer allows us to pass this component as
       // the parent, which exposes context to any child components.
-      ReactDOM.unstable_renderSubtreeIntoContainer(this, contents, doc.body.firstChild);
+      ReactDOM.unstable_renderSubtreeIntoContainer(this, contents, doc.body.children[0]);
       resetWarnings();
     } else {
       setTimeout(this.renderFrameContents, 0);

--- a/index.js
+++ b/index.js
@@ -24,9 +24,19 @@ if(hasConsole) {
 }
 
 var Frame = React.createClass({
+  // React warns when you render directly into the body since browser extensions
+  // also inject into the body and can mess up React. For this reason
+  // initialContent initialContent is expected to have a div inside of the body
+  // element that we render react into.
   propTypes: {
     style: React.PropTypes.object,
-    head:  React.PropTypes.node
+    head:  React.PropTypes.node,
+    initialContent:  React.PropTypes.string,
+  },
+  getDefaultProps: function() {
+    return {
+      initialContent: '<html><head></head><body><div></div></body></html>'
+    };
   },
   render: function() {
     // The iframe isn't ready so we drop children from props here. #12, #17
@@ -44,11 +54,12 @@ var Frame = React.createClass({
         this.props.children
       );
 
-      // React warns when you render directly into the body since browser
-      // extensions also inject into the body and can mess up React.
-      if (!this._createdDiv) {
-        doc.body.innerHTML = '<div></div>';
-        this._createdDiv = true;
+      if (!this._setInitialContent) {
+        doc.clear();
+        doc.open();
+        doc.write(this.props.initialContent);
+        doc.close();
+        this._setInitialContent = true;
       }
 
       swallowInvalidHeadWarning();

--- a/test/Frame_spec.js
+++ b/test/Frame_spec.js
@@ -30,7 +30,8 @@ describe("Frame test",function(){
 
     expect(React.createElement).toHaveBeenCalledWith('iframe',{
       children: undefined,
-      className: 'foo'
+      className: 'foo',
+      initialContent : '<html><head></head><body><div></div></body></html>'
     });
     expect(frame.props.children).toBeDefined();
   });
@@ -187,5 +188,17 @@ describe("Frame test",function(){
 
     expect(frame).not.toBeNull();
     expect(frame.contentDocument.body.innerHTML).toEqual('<div><div data-reactid=".f"><div data-reactid=".f.1">purple</div></div></div>');
+  });
+
+  it("should allow setting initialContent", function () {
+    div = document.body.appendChild(document.createElement('div'));
+
+    var initialContent = '<html><head><script>console.log("foo");</script></head><body><div></div></body></html>';
+    var renderedContent = '<html><head><script>console.log("foo");</script></head><body><div><div data-reactid=".f"></div></div></body></html>';
+    var frame = ReactDOM.render(
+      <Frame initialContent={initialContent} />
+    , div);
+    var doc = ReactDOM.findDOMNode(frame).contentDocument;
+    expect(doc.documentElement.outerHTML).toEqual(renderedContent);
   });
 });

--- a/test/Frame_spec.js
+++ b/test/Frame_spec.js
@@ -194,7 +194,7 @@ describe("Frame test",function(){
     div = document.body.appendChild(document.createElement('div'));
 
     var initialContent = '<html><head><script>console.log("foo");</script></head><body><div></div></body></html>';
-    var renderedContent = '<html><head><script>console.log("foo");</script></head><body><div><div data-reactid=".f"></div></div></body></html>';
+    var renderedContent = '<html><head><script>console.log("foo");</script></head><body><div><div data-reactid=".h"></div></div></body></html>';
     var frame = ReactDOM.render(
       <Frame initialContent={initialContent} />
     , div);


### PR DESCRIPTION
This introduces a new prop "initialContent". initialContent is injected into the
frame the first time it is rendered. That allows you to insert script tags or
whatever else into the head element. This does not attempt to update the frame
when the initialContent prop changes (hence the prop starts with "initial").