### PR TITLE
This adds contentDidUpdate as a hook to be notified when the iframe content is rendered.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,16 @@ Defaults to `'<html><head></head><body><div></div></body></html>'`
 
 The `initialContent` props is the initial html injected into frame. It is only injected once, but allows you to insert any html into the frame (e.g. a head tag, script tags, etc). Note that it does *not* update if you change the prop. Also at least one div is required in the body of the html, which we use to render the react dom into.
 
-######contentDidUpdate
+######contentDidMount and contentDidUpdate
+`contentDidMount:  React.PropTypes.func`
 `contentDidUpdate:  React.PropTypes.func`
 
-Callback called after the iframe contents have been rendered. Typically in a
-react component you would use `componentDidUpdate`. But because we do a separate
-`ReactDOM.render`, the lifecycle methods for content inside the frame are
-triggered after the lifecycle of the parent component. This provides a hook to
-know when the frame has updated.
+`contentDidMount` and `contentDidUpdate` are conceptually equivalent to
+`componentDidMount` and `componentDidUpdate`, respecitvely. The reason these are
+needed is because internally we call `ReactDOM.render` which starts a new set of
+lifecycle calls. This set of lifecycle calls are sometimes triggered after the
+lifecycle of the parent component, so these callbacks provide a hook to know
+when the frame contents are mounted and updated.
 
 ## More info
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ Defaults to `'<html><head></head><body><div></div></body></html>'`
 
 The `initialContent` props is the initial html injected into frame. It is only injected once, but allows you to insert any html into the frame (e.g. a head tag, script tags, etc). Note that it does *not* update if you change the prop. Also at least one div is required in the body of the html, which we use to render the react dom into.
 
+######contentDidUpdate
+`contentDidUpdate:  React.PropTypes.func`
+
+Callback called after the iframe contents have been rendered. Typically in a
+react component you would use `componentDidUpdate`. But because we do a separate
+`ReactDOM.render`, the lifecycle methods for content inside the frame are
+triggered after the lifecycle of the parent component. This provides a hook to
+know when the frame has updated.
+
 ## More info
 
 I wrote a [blog post] [blog-url] about building this component.

--- a/index.js
+++ b/index.js
@@ -32,11 +32,13 @@ var Frame = React.createClass({
     style: React.PropTypes.object,
     head:  React.PropTypes.node,
     initialContent:  React.PropTypes.string,
+    contentDidMount:  React.PropTypes.func,
     contentDidUpdate:  React.PropTypes.func
   },
   getDefaultProps: function() {
     return {
       initialContent: '<!DOCTYPE html><html><head></head><body><div></div></body></html>',
+      contentDidMount: function() {},
       contentDidUpdate: function() {}
     };
   },
@@ -61,6 +63,7 @@ var Frame = React.createClass({
         this.props.children
       );
 
+      var initialRender = !this._setInitialContent;
       if (!this._setInitialContent) {
         doc.clear();
         doc.open();
@@ -70,9 +73,11 @@ var Frame = React.createClass({
       }
 
       swallowInvalidHeadWarning();
+
       // unstable_renderSubtreeIntoContainer allows us to pass this component as
       // the parent, which exposes context to any child components.
-      ReactDOM.unstable_renderSubtreeIntoContainer(this, contents, doc.body.children[0], this.props.contentDidUpdate);
+      var callback = initialRender ? this.props.contentDidMount : this.props.contentDidUpdate;
+      ReactDOM.unstable_renderSubtreeIntoContainer(this, contents, doc.body.children[0], callback);
 
       resetWarnings();
     } else {

--- a/index.js
+++ b/index.js
@@ -32,10 +32,12 @@ var Frame = React.createClass({
     style: React.PropTypes.object,
     head:  React.PropTypes.node,
     initialContent:  React.PropTypes.string,
+    contentDidUpdate:  React.PropTypes.func
   },
   getDefaultProps: function() {
     return {
-      initialContent: '<!DOCTYPE html><html><head></head><body><div></div></body></html>'
+      initialContent: '<!DOCTYPE html><html><head></head><body><div></div></body></html>',
+      contentDidUpdate: function() {}
     };
   },
   render: function() {
@@ -70,7 +72,8 @@ var Frame = React.createClass({
       swallowInvalidHeadWarning();
       // unstable_renderSubtreeIntoContainer allows us to pass this component as
       // the parent, which exposes context to any child components.
-      ReactDOM.unstable_renderSubtreeIntoContainer(this, contents, doc.body.children[0]);
+      ReactDOM.unstable_renderSubtreeIntoContainer(this, contents, doc.body.children[0], this.props.contentDidUpdate);
+
       resetWarnings();
     } else {
       setTimeout(this.renderFrameContents, 0);

--- a/test/Frame_spec.js
+++ b/test/Frame_spec.js
@@ -32,6 +32,7 @@ describe("Frame test",function(){
       children: undefined,
       className: 'foo',
       initialContent: '<!DOCTYPE html><html><head></head><body><div></div></body></html>',
+      contentDidMount: jasmine.any(Function),
       contentDidUpdate: jasmine.any(Function)
     });
     expect(frame.props.children).toBeDefined();
@@ -201,5 +202,44 @@ describe("Frame test",function(){
     , div);
     var doc = ReactDOM.findDOMNode(frame).contentDocument;
     expect(doc.documentElement.outerHTML).toEqual(renderedContent);
+  });
+
+  it("should call contentDidMount on initial render", function () {
+    div = document.body.appendChild(document.createElement('div'));
+
+    var didMount = jasmine.createSpy('didMount');
+    var didUpdate = jasmine.createSpy('didUpdate');
+    var frame = ReactDOM.render(
+      <Frame contentDidMount={didMount} contentDidUpdate={didUpdate}/>
+    , div);
+
+    expect(didMount.calls.length).toEqual(1);
+    expect(didUpdate).not.toHaveBeenCalled();
+  });
+
+  it("should call contentDidUpdate on subsequent updates", function () {
+    div = document.body.appendChild(document.createElement('div'));
+
+    var didMount = jasmine.createSpy('didMount');
+    var didUpdate = jasmine.createSpy('didUpdate');
+    var frame = ReactDOM.render(
+      <Frame contentDidMount={didMount} contentDidUpdate={didUpdate}/>
+    , div);
+
+    var flag = false;
+    runs(function() {
+      frame.setState({foo: 'bar'}, function(){
+        flag = true;
+      });
+    });
+
+    waitsFor(function() {
+      return flag;
+    }, 'setState should complete', 200);
+
+    runs(function() {
+      expect(didMount.calls.length).toEqual(1);
+      expect(didUpdate.calls.length).toEqual(1);
+    });
   });
 });

--- a/test/Frame_spec.js
+++ b/test/Frame_spec.js
@@ -31,7 +31,8 @@ describe("Frame test",function(){
     expect(React.createElement).toHaveBeenCalledWith('iframe',{
       children: undefined,
       className: 'foo',
-      initialContent : '<!DOCTYPE html><html><head></head><body><div></div></body></html>'
+      initialContent: '<!DOCTYPE html><html><head></head><body><div></div></body></html>',
+      contentDidUpdate: jasmine.any(Function)
     });
     expect(frame.props.children).toBeDefined();
   });


### PR DESCRIPTION
This is needed because the ReactDOM.render starts a new set of lifecycle
renders, so a parent of a frame element's componentDidUpdate will be called
before the frame's children are updated.