### PR TITLE
Fix props.head element inside body

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,6 @@ var Frame = React.createClass({
     if(doc && doc.readyState === 'complete') {
       var contents = React.createElement('div',
         undefined,
-        this.props.head,
         this.props.children
       );
 
@@ -78,6 +77,10 @@ var Frame = React.createClass({
       // the parent, which exposes context to any child components.
       var callback = initialRender ? this.props.contentDidMount : this.props.contentDidUpdate;
       ReactDOM.unstable_renderSubtreeIntoContainer(this, contents, doc.body.children[0], callback);
+
+      if (this.props.head) {
+        ReactDOM.unstable_renderSubtreeIntoContainer(this, this.props.head, doc.querySelector('head'), callback);
+      }
 
       resetWarnings();
     } else {
@@ -98,4 +101,3 @@ var Frame = React.createClass({
 });
 
 module.exports = Frame;
-

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ var Frame = React.createClass({
       ReactDOM.unstable_renderSubtreeIntoContainer(this, contents, doc.body.children[0], callback);
 
       if (this.props.head) {
-        ReactDOM.unstable_renderSubtreeIntoContainer(this, this.props.head, doc.querySelector('head'), callback);
+        ReactDOM.unstable_renderSubtreeIntoContainer(this, this.props.head, doc.querySelector('head'));
       }
 
       resetWarnings();

--- a/test/Frame_spec.js
+++ b/test/Frame_spec.js
@@ -67,10 +67,10 @@ describe("Frame test",function(){
     var frame = ReactDOM.render(<Frame head={
           <link href='styles.css' />
         } />, div),
-        body = ReactDOM.findDOMNode(frame).contentDocument.body;
+        head = ReactDOM.findDOMNode(frame).contentDocument.head;
 
-    expect(body.querySelector('link')).toBeDefined();
-    expect(body.querySelector('link').href).toContain('styles.css');
+    expect(head.querySelector('link')).toBeDefined();
+    expect(head.querySelector('link').href).toContain('styles.css');
   });
 
   it("should create an iFrame with a <script> and insert children", function () {
@@ -81,10 +81,11 @@ describe("Frame test",function(){
           <h1>Hello</h1>
           <h2>World</h2>
         </Frame>, div),
-        body = ReactDOM.findDOMNode(frame).contentDocument.body;
+        body = ReactDOM.findDOMNode(frame).contentDocument.body,
+        head = ReactDOM.findDOMNode(frame).contentDocument.head;
 
-    expect(body.querySelector('script')).toBeDefined();
-    expect(body.querySelector('script').src).toContain('foo.js');
+    expect(head.querySelector('script')).toBeDefined();
+    expect(head.querySelector('script').src).toContain('foo.js');
     expect(frame.props.children).toBeDefined();
     expect(body.querySelectorAll('h1,h2').length).toEqual(2);
   });
@@ -96,10 +97,10 @@ describe("Frame test",function(){
           <link key='foo' href='foo.css' />,
           <script key='bar' src='bar.js' />
         ]} />, div),
-        body = ReactDOM.findDOMNode(frame).contentDocument.body;
+        head = ReactDOM.findDOMNode(frame).contentDocument.head;
 
-    expect(body.querySelectorAll('link').length).toEqual(2);
-    expect(body.querySelectorAll('script').length).toEqual(1);
+    expect(head.querySelectorAll('link').length).toEqual(2);
+    expect(head.querySelectorAll('script').length).toEqual(1);
   });
 
   it("should encapsulate styles and not effect elements outside", function () {


### PR DESCRIPTION
This patch fixes component position from `props.head`

```jsx
<Frame head={<link rel="stylesheet" href="mystyle.css" />}>
	<div>test</div>
</Frame>
```
We can see that `link` element inside `body`

![frame_2](https://cloud.githubusercontent.com/assets/4091305/14867471/b6206f6e-0cd9-11e6-9fdb-46f7b254fc1f.png)

But should be inside `head`

![frame_1](https://cloud.githubusercontent.com/assets/4091305/14867569/32c8b1ac-0cda-11e6-8ffa-bb809da061f2.png)
