### PR TITLE
Fix bug, where component re-use could cause error

### DIFF
--- a/src/Frame.jsx
+++ b/src/Frame.jsx
@@ -90,6 +90,10 @@ export default class Frame extends Component {
 
     const doc = this.getDoc();
     if (doc && doc.readyState === 'complete') {
+      if (doc.querySelector('div') === null) {
+        this._setInitialContent = false;
+      }
+
       const win = doc.defaultView || doc.parentView;
       const initialRender = !this._setInitialContent;
       const contents = (

--- a/test/Frame.spec.jsx
+++ b/test/Frame.spec.jsx
@@ -268,4 +268,47 @@ describe('The Frame Component', () => {
 
     expect(Frame.prototype.getMountTarget.call(frame)).to.equal(body.querySelector('#container'));
   });
+
+  it('Should not error when parent components are reused', () => {
+    div = document.body.appendChild(document.createElement('div'));
+    const component = ReactDOM.render(
+      <ul className="container">
+        <li key="1">
+          <Frame>
+            <p>Text 1</p>
+          </Frame>
+        </li>
+        <li key="2">
+          <Frame>
+            <p>Text 2</p>
+          </Frame>
+        </li>
+      </ul>,
+      div,
+    );
+
+    const iframes1 = ReactDOM.findDOMNode(component).querySelectorAll('iframe');
+    expect(iframes1[0].contentDocument.body.querySelector('p').textContent).to.equal('Text 1');
+    expect(iframes1[1].contentDocument.body.querySelector('p').textContent).to.equal('Text 2');
+
+    const component2 = ReactDOM.render(
+      <ul className="container">
+        <li key="2">
+          <Frame>
+            <p>Text 2</p>
+          </Frame>
+        </li>
+        <li key="1">
+          <Frame>
+            <p>Text 1</p>
+          </Frame>
+        </li>
+      </ul>,
+      div,
+    );
+
+    const iframes2 = ReactDOM.findDOMNode(component2).querySelectorAll('iframe');
+    expect(iframes2[0].contentDocument.body.querySelector('p').textContent).to.equal('Text 2');
+    expect(iframes2[1].contentDocument.body.querySelector('p').textContent).to.equal('Text 1');
+  });
 });


### PR DESCRIPTION
## Scenario
We're using react-frame-component in a list. And since react whats to be smart about reusing DOM node we provide a key.
```
<ul>
    <li key="1">
        <Frame><p>hello 1</p></Frame>
    </li>
    <li key="2">
        <Frame><p>hello 2</p></Frame>
    </li>
</ul>
```
## Problem
The problem starts when the list is reordered. React detaches and add the component(s), however [iFrames can not be moved without loosing state](http://stackoverflow.com/questions/8318264/how-to-move-an-iframe-in-the-dom-without-losing-its-state). After reorder the temporary detached iframe will reload. An error is then thrown, since the mount-div we're relying, does not longer exist. Thankfully this could be reproduced in a test 🎉 .

## Solution
I added [a check before for the existence of the mount target div](https://github.com/aronwoost/react-frame-component/blob/f30328987db6447bcf561b67b2449b72a20dbe32/src/Frame.jsx#L93-L95). I have not found a solution to get informed about iFrame "reload", there does not seam to be an event for that. Also there is no (private) React API about DOM detaching.