### PR TITLE
Prevent Document.open call from adding browser history entry

### DIFF
--- a/src/Frame.jsx
+++ b/src/Frame.jsx
@@ -106,7 +106,7 @@ export default class Frame extends Component {
       );
 
       if (initialRender) {
-        doc.open();
+        doc.open('text/html', 'replace');
         doc.write(this.props.initialContent);
         doc.close();
         this._setInitialContent = true;


### PR DESCRIPTION
Fixes #57. Appearently this is a (somewhat) known issue when writing to a `Document` inside an iframe. There's a [bug report](https://bugzilla.mozilla.org/show_bug.cgi?id=148794) on Bugzilla and an [SO question](http://stackoverflow.com/a/32677679/618739) where I took the solution from.