### PR TITLE
Use new prop-types package instead of React.PropTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,19 +44,19 @@ React.render(
 ##### Props:
 
 ###### head
-`head:  React.PropTypes.node`
+`head:  PropTypes.node`
 
 The `head` prop is a dom node that gets inserted before the children of the frame. Note that this is injected into the body of frame (see the blog post for why). This has the benefit of being able to update and works for stylesheets.
 
 ###### initialContent
-`initialContent:  React.PropTypes.string`
+`initialContent:  PropTypes.string`
 
 Defaults to `'<!DOCTYPE html><html><head></head><body><div></div></body></html>'`
 
 The `initialContent` props is the initial html injected into frame. It is only injected once, but allows you to insert any html into the frame (e.g. a head tag, script tags, etc). Note that it does *not* update if you change the prop. Also at least one div is required in the body of the html, which we use to render the react dom into.
 
 ###### mountTarget
-`mountTarget:  React.PropTypes.string`
+`mountTarget:  PropTypes.string`
 
 The `mountTarget` props is a css selector (#target/.target) that specifies where in the `initialContent` of the iframe, children will be mounted.
 
@@ -69,8 +69,8 @@ The `mountTarget` props is a css selector (#target/.target) that specifies where
 ```
 
 ###### contentDidMount and contentDidUpdate
-`contentDidMount:  React.PropTypes.func`
-`contentDidUpdate:  React.PropTypes.func`
+`contentDidMount:  PropTypes.func`
+`contentDidUpdate:  PropTypes.func`
 
 `contentDidMount` and `contentDidUpdate` are conceptually equivalent to
 `componentDidMount` and `componentDidUpdate`, respecitvely. The reason these are
@@ -88,7 +88,7 @@ const MyComponent = (props, context) => {
     document: iframeDocument,
     window: iframeWindow
   } = context;
-  
+
   return (<...rendered jsx.../>);
 };
 

--- a/example/Application.jsx
+++ b/example/Application.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Frame from '../src';
 
 const InnerFrame = (props, context) => {

--- a/package.json
+++ b/package.json
@@ -64,9 +64,10 @@
     "mocha-multi": "^0.10.0",
     "mocha-osx-reporter": "^0.1.2",
     "npm-run-all": "^4.0.1",
-    "react": "^15.0.1",
+    "prop-types": "^15.5.9",
+    "react": "^15.5.4",
     "react-addons-test-utils": "^15.0.1",
-    "react-dom": "^15.0.1",
+    "react-dom": "^15.5.4",
     "rimraf": "^2.5.4",
     "sinon": "2.0.0-pre",
     "wallaby-webpack": "^0.0.30",
@@ -75,7 +76,8 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "react": "^15.0.1",
-    "react-dom": "^15.0.1"
+    "prop-types": "^15.5.9",
+    "react": "^15.5.9",
+    "react-dom": "^15.5.9"
   }
 }

--- a/src/DocumentContext.jsx
+++ b/src/DocumentContext.jsx
@@ -1,4 +1,5 @@
-import React, { Component, Children, PropTypes } from 'react'; // eslint-disable-line no-unused-vars
+import React, { Component, Children } from 'react'; // eslint-disable-line no-unused-vars
+import PropTypes from 'prop-types';
 
 export default class DocumentContext extends Component {
   static propTypes = {

--- a/src/Frame.jsx
+++ b/src/Frame.jsx
@@ -1,5 +1,6 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 import DocumentContext from './DocumentContext';
 
 const hasConsole = typeof window !== 'undefined' && window.console;

--- a/test/DocumentContext.spec.jsx
+++ b/test/DocumentContext.spec.jsx
@@ -1,5 +1,6 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 import ReactTestUtils from 'react-addons-test-utils';
 import { expect } from 'chai';
 import DocumentContext from '../src/DocumentContext';

--- a/test/Frame.spec.jsx
+++ b/test/Frame.spec.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-addons-test-utils';
 import { expect } from 'chai';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2039,9 +2039,9 @@ faye-websocket@~0.11.0:
   dependencies:
     websocket-driver ">=0.5.1"
 
-fbjs@^0.8.1, fbjs@^0.8.4:
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.8.tgz#02f1b6e0ea0d46c24e0b51a2d24df069563a5ad6"
+fbjs@^0.8.4, fbjs@^0.8.9:
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -3070,7 +3070,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -3730,6 +3730,13 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@^15.5.7, prop-types@^15.5.9, prop-types@~15.5.7:
+  version "15.5.9"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.9.tgz#d478eef0e761396942f70c78e772f76e8be747c9"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
@@ -3834,21 +3841,23 @@ react-addons-test-utils@^15.0.1:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
-react-dom@^15.0.1:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.4.2.tgz#015363f05b0a1fd52ae9efdd3a0060d90695208f"
+react-dom@^15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.5.4.tgz#ba0c28786fd52ed7e4f2135fe0288d462aef93da"
   dependencies:
-    fbjs "^0.8.1"
+    fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+    prop-types "~15.5.7"
 
-react@^15.0.1:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.4.2.tgz#41f7991b26185392ba9bae96c8889e7e018397ef"
+react@^15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
   dependencies:
-    fbjs "^0.8.4"
+    fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+    prop-types "^15.5.7"
 
 read-pkg@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Using React.PropTypes has been deprecated, we should use the new 'prop-types' package instead.

Fixes #67 