### PR TITLE
Support document.fonts.status on supported browser with build

### DIFF
--- a/src/Frame.jsx
+++ b/src/Frame.jsx
@@ -89,41 +89,57 @@ export default class Frame extends Component {
     }
 
     const doc = this.getDoc();
-    if (doc && doc.readyState === 'complete') {
-      if (doc.querySelector('div') === null) {
-        this._setInitialContent = false;
-      }
 
-      const win = doc.defaultView || doc.parentView;
-      const initialRender = !this._setInitialContent;
-      const contents = (
-        <DocumentContext document={doc} window={win}>
-          <div className="frame-content">
-            {this.props.head}
-            {this.props.children}
-          </div>
-        </DocumentContext>
-      );
-
-      if (initialRender) {
-        doc.open('text/html', 'replace');
-        doc.write(this.props.initialContent);
-        doc.close();
-        this._setInitialContent = true;
-      }
-
-      swallowInvalidHeadWarning();
-
-      // unstable_renderSubtreeIntoContainer allows us to pass this component as
-      // the parent, which exposes context to any child components.
-      const callback = initialRender ? this.props.contentDidMount : this.props.contentDidUpdate;
-      const mountTarget = this.getMountTarget();
-
-      ReactDOM.unstable_renderSubtreeIntoContainer(this, contents, mountTarget, callback);
-      resetWarnings();
-    } else {
+    if (!doc) {
+      // not ready, try next tick
       setTimeout(this.renderFrameContents.bind(this), 0);
+      return;
     }
+
+    if (doc.readyState !== 'complete') {
+      // not ready, try next tick
+      setTimeout(this.renderFrameContents.bind(this), 0);
+      return;
+    }
+
+    // only for browsers that support document.fonts
+    if (doc.fonts && doc.fonts.status !== 'loaded') {
+      // not ready, try next tick
+      setTimeout(this.renderFrameContents.bind(this), 0);
+      return;
+    }
+
+    if (doc.querySelector('div') === null) {
+      this._setInitialContent = false;
+    }
+
+    const win = doc.defaultView || doc.parentView;
+    const initialRender = !this._setInitialContent;
+    const contents = (
+      <DocumentContext document={doc} window={win}>
+        <div className="frame-content">
+          {this.props.head}
+          {this.props.children}
+        </div>
+      </DocumentContext>
+    );
+
+    if (initialRender) {
+      doc.open('text/html', 'replace');
+      doc.write(this.props.initialContent);
+      doc.close();
+      this._setInitialContent = true;
+    }
+
+    swallowInvalidHeadWarning();
+
+    // unstable_renderSubtreeIntoContainer allows us to pass this component as
+    // the parent, which exposes context to any child components.
+    const callback = initialRender ? this.props.contentDidMount : this.props.contentDidUpdate;
+    const mountTarget = this.getMountTarget();
+
+    ReactDOM.unstable_renderSubtreeIntoContainer(this, contents, mountTarget, callback);
+    resetWarnings();
   }
 
   render() {


### PR DESCRIPTION
This PR add the detection of webfonts being loaded on supported browsers. Since webfonts typically cause reflow of elements, it's useful to now when page is "really" loaded.

This is done via the [FontFaceSet API](https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet) that is supported by some browsers.

While this PR does not include tests for this behavior (is kinda hard to mock all that stuff), the existing tests do confirm that nothing breaks on not-supported-browser since Phantom doesn't support it.

I also changed the if clause around to make it more readable.