### PR TITLE
Switch to react-dom for ReactTestUtils

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "npm-run-all": "^4.0.1",
     "prop-types": "^15.5.9",
     "react": "^15.5.4",
-    "react-addons-test-utils": "^15.0.1",
     "react-dom": "^15.5.4",
     "rimraf": "^2.5.4",
     "sinon": "2.0.0-pre",

--- a/test/DocumentContext.spec.jsx
+++ b/test/DocumentContext.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
-import ReactTestUtils from 'react-addons-test-utils';
+import ReactTestUtils from 'react-dom/test-utils';
 import { expect } from 'chai';
 import DocumentContext from '../src/DocumentContext';
 

--- a/test/Frame.spec.jsx
+++ b/test/Frame.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-import ReactTestUtils from 'react-addons-test-utils';
+import ReactTestUtils from 'react-dom/test-utils';
 import { expect } from 'chai';
 import sinon from 'sinon/pkg/sinon';
 import Frame from '../src';


### PR DESCRIPTION
`react-addons-test-utils` was deprecated as of version 15.5.0