### PR TITLE
Fix peerDepencies versions for react and react-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "dependencies": {},
   "peerDependencies": {
     "prop-types": "^15.5.9",
-    "react": "^15.5.9",
-    "react-dom": "^15.5.9"
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4"
   }
 }


### PR DESCRIPTION
`package.json` is referring to peerDependencies versions that do (not?) yet exist for `react` and `react-dom` leading to `UNMET PEER DEPENDENCY` warnings in npm.