### PR TITLE
Updates README to reflect move from React.render => ReactDOM.render

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ var Header = React.createClass({
   }
 });
 
-React.render(<Header>Hello</Header>, document.body);
+ReactDOM.render(<Header>Hello</Header>, document.body);
 ```
 
 Or you can wrap it at the `render` call.
 
 ```html
-React.render(
+ReactDOM.render(
   <Frame>
     <Header>Hello</Header>
   </Frame>,


### PR DESCRIPTION
This is pretty closely related to https://github.com/ryanseddon/react-frame-component/pull/77.

Would be good to make this change so users don't see deprecation warnings / errors.