### PR TITLE
Replace document.write with innerHTML so initialContent injection does not break scripts

### DIFF
--- a/src/Frame.jsx
+++ b/src/Frame.jsx
@@ -95,9 +95,7 @@ export default class Frame extends Component {
     );
 
     if (initialRender) {
-      doc.open('text/html', 'replace');
-      doc.write(this.props.initialContent);
-      doc.close();
+      doc.documentElement.innerHTML = this.props.initialContent;
       this._setInitialContent = true;
     }
 


### PR DESCRIPTION
Instead of using `document.write` to inject `initialContent` we can use `innerHTML` for the same purpose which does not break `<script>` injection.