### PR TITLE
adding external iframe ref options 

### DIFF
--- a/src/Frame.jsx
+++ b/src/Frame.jsx
@@ -35,7 +35,6 @@ export default class Frame extends Component {
     initialContent: PropTypes.string,
     skipInitialRender: PropTypes.bool,
     documentRef: PropTypes.object,
-    RenderElement: PropTypes.node,
     mountTarget: PropTypes.string,
     contentDidMount: PropTypes.func,
     contentDidUpdate: PropTypes.func,
@@ -52,7 +51,6 @@ export default class Frame extends Component {
     mountTarget: undefined,
     skipInitialRender: false,
     documentRef: null,
-    RenderElement: 'div',
     contentDidMount: () => {},
     contentDidUpdate: () => {},
     initialContent: '<!DOCTYPE html><html><head></head><body><div class="frame-root"></div></body></html>'
@@ -137,9 +135,8 @@ export default class Frame extends Component {
 
   render() {
     // If the render element is set, simply return that
-    if (this.props.documentRef && this.props.RenderElement) {
-      const { RenderElement } = this.props;
-      return <RenderElement />;
+    if (this.props.documentRef) {
+      return null;
     }
 
     const props = {
@@ -152,7 +149,6 @@ export default class Frame extends Component {
     delete props.mountTarget;
     delete props.skipInitialRender;
     delete props.documentRef;
-    delete props.RenderElement;
     delete props.contentDidMount;
     delete props.contentDidUpdate;
 

--- a/src/Frame.jsx
+++ b/src/Frame.jsx
@@ -134,7 +134,7 @@ export default class Frame extends Component {
   }
 
   render() {
-    // If the render element is set, simply return that
+    // If existing documentRef is set, simply return null
     if (this.props.documentRef) {
       return null;
     }

--- a/test/Frame.spec.jsx
+++ b/test/Frame.spec.jsx
@@ -336,7 +336,7 @@ describe('The Frame Component with Reference', () => {
     iframe = document.body.appendChild(document.createElement('iframe'));
 
     const frame = ReactDOM.render(
-      <Frame documentRef={iframe.contentDocument} RenderElement="section" />,
+      <Frame documentRef={iframe.contentDocument} />,
       div
     );
     const body = iframe.contentDocument.body;
@@ -350,7 +350,7 @@ describe('The Frame Component with Reference', () => {
     iframe = document.body.appendChild(document.createElement('iframe'));
 
     ReactDOM.render(
-      <Frame documentRef={iframe.contentDocument} RenderElement="section">
+      <Frame documentRef={iframe.contentDocument}>
         <p>Test 1</p>
       </Frame>,
       div,
@@ -371,7 +371,6 @@ describe('The Frame Component with Reference', () => {
     const frame = ReactDOM.render(
       <Frame
         documentRef={iframe.contentDocument}
-        RenderElement="section"
         skipInitialRender
         mountTarget="#alt-root"
       />,

--- a/test/Frame.spec.jsx
+++ b/test/Frame.spec.jsx
@@ -319,3 +319,66 @@ describe('The Frame Component', () => {
     expect(iframes2[1].contentDocument.body.querySelector('p').textContent).to.equal('Text 1');
   });
 });
+
+describe('The Frame Component with Reference', () => {
+  let div;
+  let iframe;
+
+  afterEach(() => {
+    if (div) {
+      div.parentNode.removeChild(div);
+      div = null;
+    }
+  });
+
+  it('should allow an external iframe reference', () => {
+    div = document.body.appendChild(document.createElement('div'));
+    iframe = document.body.appendChild(document.createElement('iframe'));
+
+    const frame = ReactDOM.render(
+      <Frame documentRef={iframe.contentDocument} RenderElement="section" />,
+      div
+    );
+    const body = iframe.contentDocument.body;
+    div = document.body.appendChild(document.createElement('div'));
+
+    expect(Frame.prototype.getMountTarget.call(frame)).to.equal(body.querySelector('.frame-root'));
+  });
+
+  it('should re-render inside the iframe correctly', () => {
+    div = document.body.appendChild(document.createElement('div'));
+    iframe = document.body.appendChild(document.createElement('iframe'));
+
+    ReactDOM.render(
+      <Frame documentRef={iframe.contentDocument} RenderElement="section">
+        <p>Test 1</p>
+      </Frame>,
+      div,
+    );
+    const body1 = iframe.contentDocument.body;
+    const p1 = body1.querySelector('p');
+
+    expect(p1.textContent).to.equal('Test 1');
+  });
+
+  it('should allow content rewrite to be skipped', () => {
+    div = document.body.appendChild(document.createElement('div'));
+    iframe = document.body.appendChild(document.createElement('iframe'));
+
+    const body = iframe.contentDocument.body;
+    const innerSection = body.appendChild(iframe.contentDocument.createElement('section'));
+    innerSection.id = 'alt-root';
+    const frame = ReactDOM.render(
+      <Frame
+        documentRef={iframe.contentDocument}
+        RenderElement="section"
+        skipInitialRender
+        mountTarget="#alt-root"
+      />,
+      div
+    );
+    div = document.body.appendChild(document.createElement('div'));
+
+    expect(Frame.prototype.getMountTarget.call(frame)).to.equal(body.querySelector('#alt-root'));
+  });
+});


### PR DESCRIPTION
Adds 3 additional props that would allow for external iframe refs to be used for the document.  
```
{    
   skipInitialRender: false,
   documentRef: null,
   RenderElement: 'div',
}
```
Some rudimentary tests were also added.  See https://github.com/ryanseddon/react-frame-component/issues/83