### PR TITLE
Don't unmountComponentAtNode unless the mount target exists

### DIFF
--- a/src/Frame.jsx
+++ b/src/Frame.jsx
@@ -67,8 +67,9 @@ export default class Frame extends Component {
   componentWillUnmount() {
     this._isMounted = false;
     const doc = this.getDoc();
-    if (doc) {
-      ReactDOM.unmountComponentAtNode(this.getMountTarget());
+    const mountTarget = this.getMountTarget();
+    if (doc && mountTarget) {
+      ReactDOM.unmountComponentAtNode(mountTarget);
     }
   }
 


### PR DESCRIPTION
In some automated tests I was running I found that every once in a while
this would happen:
1. frame component is mounted
2. iframe / doc are created (but subtree is not yet rendered into iframe)
3. frame component is unmounted

In this case unmounting the frame component would lead to an error since
the mount target would be undefined.

This commit checks that both the doc and mountTarget exist before
calling unmountComponentAtNode.