### PR TITLE
Null check for doc

### DIFF
--- a/src/Frame.jsx
+++ b/src/Frame.jsx
@@ -78,6 +78,10 @@ export default class Frame extends Component {
 
     const doc = this.getDoc();
 
+    if (!doc) {
+      return null;
+    }
+
     const contentDidMount = this.props.contentDidMount;
     const contentDidUpdate = this.props.contentDidUpdate;
 

--- a/src/Frame.jsx
+++ b/src/Frame.jsx
@@ -56,7 +56,7 @@ export default class Frame extends Component {
   }
 
   getDoc() {
-    return this.node.contentDocument; // eslint-disable-line
+    return this.node ? this.node.contentDocument : null; // eslint-disable-line
   }
 
   getMountTarget() {

--- a/test/Frame.spec.jsx
+++ b/test/Frame.spec.jsx
@@ -11,7 +11,7 @@ describe('The Frame Component', () => {
 
   afterEach(() => {
     if (div) {
-      div.parentNode.removeChild(div);
+      div.remove();
       div = null;
     }
   });
@@ -347,5 +347,12 @@ describe('The Frame Component', () => {
     expect(
       iframes2[1].contentDocument.body.querySelector('p').textContent
     ).to.equal('Text 1');
+  });
+
+  it('should not error when the root component is removed', () => {
+    div = document.body.appendChild(document.createElement('div'));
+    ReactDOM.render(<Frame />, div);
+    div.remove();
+    ReactDOM.render(<Frame />, div);
   });
 });


### PR DESCRIPTION
We've had some issues where `doc` is null and then it throws a `'defaultView' of null` exception when attempting to get the `doc.defaultView`.

I have been unable to repeat the issue locally but it's happened a few hundred times according to some of the analytics I've recovered.

This simple check will not render until that ref is resolved, similar to `!_isMounted`.