### PR TITLE
fix: Prevent load during render

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,9 +4,7 @@ const webpack = {
     extensions: ['', '.js', '.jsx']
   },
   module: {
-    noParse: [
-      /node_modules\/sinon/
-    ],
+    noParse: [/node_modules\/sinon/],
     loaders: [
       { test: /\.js(x|)$/, loader: 'babel-loader', exclude: /node_modules/ },
       { test: /\.json$/, loader: 'json-loader' }
@@ -17,9 +15,7 @@ const webpack = {
 module.exports = function configure(config) {
   config.set({
     basePath: '',
-    files: [
-      { pattern: 'test/**/*.spec.js*', watched: true }
-    ],
+    files: [{ pattern: 'test/**/*.spec.js*', watched: true }],
     preprocessors: {
       'test/**/*.spec.js*': ['webpack', 'sourcemap']
     },
@@ -29,7 +25,8 @@ module.exports = function configure(config) {
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
-    autoWatch: false,
+    autoWatch: true,
+    singleRun: false,
     browsers: ['ChromeHeadlessNoSandbox'],
     customLaunchers: {
       ChromeHeadlessNoSandbox: {

--- a/src/Frame.jsx
+++ b/src/Frame.jsx
@@ -42,6 +42,12 @@ export default class Frame extends Component {
     this._isMounted = true;
 
     const doc = this.getDoc();
+    if (doc) {
+      doc.open('text/html', 'replace');
+      doc.write(this.props.initialContent);
+      doc.close();
+    }
+
     if (doc && doc.readyState === 'complete') {
       this.forceUpdate();
     } else {
@@ -86,7 +92,6 @@ export default class Frame extends Component {
     const contentDidUpdate = this.props.contentDidUpdate;
 
     const win = doc.defaultView || doc.parentView;
-    const initialRender = !this._setInitialContent;
     const contents = (
       <Content
         contentDidMount={contentDidMount}
@@ -97,13 +102,6 @@ export default class Frame extends Component {
         </FrameContextProvider>
       </Content>
     );
-
-    if (initialRender) {
-      doc.open('text/html', 'replace');
-      doc.write(this.props.initialContent);
-      doc.close();
-      this._setInitialContent = true;
-    }
 
     const mountTarget = this.getMountTarget();
 

--- a/src/Frame.jsx
+++ b/src/Frame.jsx
@@ -55,6 +55,16 @@ export default class Frame extends Component {
     }
   }
 
+  componentDidUpdate() {
+    const doc = this.getDoc();
+    if (doc && doc.body.children.length < 1) {
+      doc.open('text/html', 'replace');
+      doc.write(this.props.initialContent);
+      doc.close();
+      this.forceUpdate();
+    }
+  }
+
   componentWillUnmount() {
     this._isMounted = false;
 
@@ -104,6 +114,9 @@ export default class Frame extends Component {
     );
 
     const mountTarget = this.getMountTarget();
+    if (mountTarget === undefined) {
+      return null;
+    }
 
     return [
       ReactDOM.createPortal(this.props.head, this.getDoc().head),

--- a/test/Frame.spec.jsx
+++ b/test/Frame.spec.jsx
@@ -356,7 +356,7 @@ describe('The Frame Component', () => {
     ReactDOM.render(<Frame />, div);
   });
 
-  it('should not error when root component is re-appended', () => {
+  it.only('should not error when root component is re-appended', () => {
     div = document.body.appendChild(document.createElement('div'));
     ReactDOM.render(<Frame />, div);
     document.body.append(div);


### PR DESCRIPTION
Currently the render of `Frame` is not side-effect free since it calls `document.write`. In `react@experimental` (`0.0.0-experimental-e5d06e34b`) this will issue a warning since `document.close()` dispatches a `load` event during `render`. If we encounter a `load` event we call `this.forceUpdate()` which is an update (`forceUpdate`) during a state transition (`render`).

Proof-of-concept of this fix: https://codesandbox.io/s/documentwrite-in-cdm-b3xzf?file=/src/index.js:367-532
If you move the `document.write` to `renderContents` you'll see the warning in the console.