### PR TITLE
Use `PropTypes.node` for `children` prop type

### DIFF
--- a/src/Frame.jsx
+++ b/src/Frame.jsx
@@ -16,10 +16,7 @@ export default class Frame extends Component {
     mountTarget: PropTypes.string,
     contentDidMount: PropTypes.func,
     contentDidUpdate: PropTypes.func,
-    children: PropTypes.oneOfType([
-      PropTypes.element,
-      PropTypes.arrayOf(PropTypes.element)
-    ])
+    children: PropTypes.node
   };
 
   static defaultProps = {


### PR DESCRIPTION
I think that the `node` prop type is a better choice for the `children` prop type here.