### PR TITLE
Forward iframe ref and use React.createRef

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,32 @@ lifecycle calls. This set of lifecycle calls are sometimes triggered after the
 lifecycle of the parent component, so these callbacks provide a hook to know
 when the frame contents are mounted and updated.
 
-###### Accessing the iframe's window and document
+###### ref
+`ref: PropTypes.oneOfType([ PropTypes.func, PropTypes.shape({ current: PropTypes.instanceOf(Element) }) ])`
+
+The `ref` prop provides a way to access inner iframe DOM node. To utilitize this prop use, for example, one of the React's built-in methods to create a ref: [`React.createRef()`](https://reactjs.org/docs/refs-and-the-dom.html#creating-refs) or [`React.useRef()`](https://reactjs.org/docs/hooks-reference.html#useref).
+
+```js
+const MyComponent = (props) => {
+  const iframeRef = React.useRef();
+
+  React.useEffect(() => {
+    // Use iframeRef for:
+    // - focus managing
+    // - triggering imperative animations
+    // - integrating with third-party DOM libraries
+    iframeRef.current.focus()
+  }, [])
+
+  return (
+    <Frame ref={iframeRef}>
+      <InnerComponent />
+    </Frame>
+  );
+}
+```
+
+##### Accessing the iframe's window and document
 The iframe's `window` and `document` may be accessed via the `FrameContextConsumer` or the `useFrame` hook.
 
 The example with `FrameContextConsumer`:

--- a/src/Frame.jsx
+++ b/src/Frame.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { FrameContextProvider } from './Context';
 import Content from './Content';
 
-export default class Frame extends Component {
+export class Frame extends Component {
   // React warns when you render directly into the body since browser extensions
   // also inject into the body and can mess up React. For this reason
   // initialContent is expected to have a div inside of the body
@@ -36,6 +36,7 @@ export default class Frame extends Component {
   constructor(props, context) {
     super(props, context);
     this._isMounted = false;
+    this.nodeRef = React.createRef();
     this.state = { iframeLoaded: false };
   }
 
@@ -46,18 +47,18 @@ export default class Frame extends Component {
     if (doc && doc.readyState === 'complete') {
       this.forceUpdate();
     } else {
-      this.node.addEventListener('load', this.handleLoad);
+      this.nodeRef.current.addEventListener('load', this.handleLoad);
     }
   }
 
   componentWillUnmount() {
     this._isMounted = false;
 
-    this.node.removeEventListener('load', this.handleLoad);
+    this.nodeRef.current.removeEventListener('load', this.handleLoad);
   }
 
   getDoc() {
-    return this.node ? this.node.contentDocument : null; // eslint-disable-line
+    return this.nodeRef.current ? this.nodeRef.current.contentDocument : null; // eslint-disable-line
   }
 
   getMountTarget() {
@@ -69,7 +70,14 @@ export default class Frame extends Component {
   }
 
   setRef = node => {
-    this.node = node;
+    this.nodeRef.current = node;
+
+    const { forwardedRef } = this.props; // eslint-disable-line react/prop-types
+    if (typeof forwardedRef === 'function') {
+      forwardedRef(node);
+    } else if (forwardedRef) {
+      forwardedRef.current = node;
+    }
   };
 
   handleLoad = () => {
@@ -121,6 +129,7 @@ export default class Frame extends Component {
     delete props.mountTarget;
     delete props.contentDidMount;
     delete props.contentDidUpdate;
+    delete props.forwardedRef;
     return (
       <iframe {...props} ref={this.setRef} onLoad={this.handleLoad}>
         {this.state.iframeLoaded && this.renderFrameContents()}
@@ -128,3 +137,7 @@ export default class Frame extends Component {
     );
   }
 }
+
+export default React.forwardRef((props, ref) => (
+  <Frame {...props} forwardedRef={ref} />
+));

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-import Frame from './Frame';
+export { default } from './Frame';
 
 export { FrameContext, FrameContextConsumer } from './Context';
-
-export default Frame;

--- a/test/Frame.spec.jsx
+++ b/test/Frame.spec.jsx
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
 import { expect } from 'chai';
 import sinon from 'sinon/pkg/sinon';
-import Frame from '../src';
+import ForwardedRefFrame, { Frame } from '../src/Frame';
 
 describe('The Frame Component', () => {
   let div;
@@ -424,12 +424,23 @@ describe('The Frame Component', () => {
         contentDidMount={() => {
           const iframes = ReactDOM.findDOMNode(div).querySelectorAll('iframe');
 
-    expect(iframes[0].contentDocument.body.children.length).to.equal(1);
+          expect(iframes[0].contentDocument.body.children.length).to.equal(1);
           expect(iframes[0].contentDocument.body.children.length).to.equal(1);
           done();
         }}
       />,
       div
     );
+  });
+
+  it('should properly assign ref prop', done => {
+    div = document.body.appendChild(document.createElement('div'));
+
+    const ref = sinon.spy(iframe => {
+      expect(iframe instanceof HTMLIFrameElement).to.equal(true);
+      done();
+    });
+
+    ReactDOM.render(<ForwardedRefFrame ref={ref} />, div);
   });
 });


### PR DESCRIPTION
This PR resolves #151 and potentially fixes #158.

Allow to pass `ref` prop to `Frame` component which will allow to reach the inner `iframe` `HTMLIFrameElement`.
The ref forwarding is done by `React.forwardRef` helper which wraps the original `Frame` class component instance. 

Additionally as mentioned in the issue #158  description it would be nice to use `React.createRef` instance for handling `<iframe />`  instance reference.

Example usage:
```ts
function Foo() {
  const iframeRef = React.useRef()

  React.useEffect(() => {
    iframe.style.setProperty('background-color', 'pink');
  }, [])

  <Frame ref={iframeRef} />
}
```