### PR TITLE
useFrame hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ lifecycle of the parent component, so these callbacks provide a hook to know
 when the frame contents are mounted and updated.
 
 ###### Accessing the iframe's window and document
-The iframe's `window` and `document` may be accessed via the FrameContextConsumer.
+The iframe's `window` and `document` may be accessed via the `FrameContextConsumer` or the `useFrame` hook.
+
+The example with `FrameContextConsumer`:
 
 ```js
 import Frame, { FrameContextConsumer } from 'react-frame-component'
@@ -94,6 +96,25 @@ const MyComponent = (props, context) => (
   </Frame>
 );
 
+```
+
+The example with `useFrame` hook:
+
+```js
+import Frame, { useFrame } from 'react-frame-component';
+
+const InnerComponent = () => {
+  // Hook returns iframe's window and document instances from Frame context
+  const { document, window } = useFrame();
+
+  return null;
+};
+
+const OuterComponent = () => (
+  <Frame>
+    <InnerComponent />
+  </Frame>
+);
 ```
 
 ## More info

--- a/src/Context.jsx
+++ b/src/Context.jsx
@@ -11,6 +11,8 @@ if (typeof window !== 'undefined') {
 
 export const FrameContext = React.createContext({ document: doc, window: win });
 
+export const useFrame = () => React.useContext(FrameContext);
+
 export const {
   Provider: FrameContextProvider,
   Consumer: FrameContextConsumer

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import Frame from './Frame';
 
-export { FrameContext, FrameContextConsumer } from './Context';
+export { FrameContext, FrameContextConsumer, useFrame } from './Context';
 
 export default Frame;

--- a/test/Context.spec.jsx
+++ b/test/Context.spec.jsx
@@ -4,7 +4,8 @@ import { expect } from 'chai';
 import {
   FrameContextProvider,
   FrameContextConsumer,
-  FrameContext
+  FrameContext,
+  useFrame
 } from '../src/Context';
 
 describe('The DocumentContext Component', () => {
@@ -45,6 +46,29 @@ describe('The DocumentContext Component', () => {
       }
     }
     Child.contextType = FrameContext;
+
+    ReactTestUtils.renderIntoDocument(
+      <FrameContextProvider value={{ document, window }}>
+        <Child />
+      </FrameContextProvider>
+    );
+  });
+
+  it('exports full context instance to allow accessing via custom hook', done => {
+    const document = { foo: 1 };
+    const window = { bar: 2 };
+
+    const Child = () => {
+      const frame = useFrame();
+
+      React.useEffect(() => {
+        expect(frame.document).to.deep.equal(document);
+        expect(frame.window).to.deep.equal(window);
+        done();
+      }, []);
+
+      return null;
+    };
 
     ReactTestUtils.renderIntoDocument(
       <FrameContextProvider value={{ document, window }}>


### PR DESCRIPTION
This PR extends the possible usage options by adding a custom hook `useFrame` to align with the more modern React practice of consuming `Context`. It is a simple wrapper on `React.useContext`.

Thanks to this hook usage of render prop pattern with `Consumer` component is not needed in function components and it can be done just like that:
```js
function Foo (props) {
  const { window, document } = useFrame();

  /* rest of the component */
}
```