### PR TITLE
Include index.ts in npm tar ball

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "React component to wrap your application or component in an iFrame for encapsulation purposes",
   "main": "lib/index.js",
   "files": [
-    "lib"
+    "lib",
+    "index.ts"
   ],
   "scripts": {
     "precommit": "lint-staged",


### PR DESCRIPTION
Seems when we did #167 we forgot to include `index.ts` in #129 in the package.json files property. 

Adding `index.ts` will include it in the tarball uploaded to npm.