### PR TITLE
fix: use correct value type for ref prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ declare module 'react-frame-component' {
     contentDidMount?: (() => void) | undefined;
     contentDidUpdate?: (() => void) | undefined;
     children: React.ReactNode;
-    ref?: React.Ref<FrameComponent>;
+    ref?: React.Ref<HTMLIFrameElement>;
   }
 
   export default class FrameComponent extends React.Component<


### PR DESCRIPTION
The underlying value of the Frame's ref should be a handle to the iframe element (`HTMLIFrameElement`) instead of `FrameComponent`.