### PR TITLE
Fix TypeScript Error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,9 +12,8 @@ declare module 'react-frame-component' {
     ref?: React.Ref<HTMLIFrameElement>;
   }
 
-  export default class FrameComponent extends React.Component<
-    FrameComponentProps
-  > {}
+  const FrameComponent: React.Component<FrameComponentProps>;
+  export default FrameComponent;
 
   export interface FrameContextProps {
     document?: HTMLDocument;


### PR DESCRIPTION
Hi, I have TypeScript 4.6.4 and Preact, and I get this error:
`'Frame' cannot be used as a JSX component. Its instance type 'FrameComponent' is not a valid JSX element.`

Here is my `package.json` https://github.com/emirsavran/vite-preact-widget-starter/blob/main/package.json
I fixed this with these changes. I'm not a TypeScript expert, I'm not sure if it breaks types for older versions or not.