### PR TITLE
fix: change default export away from React.Component

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,19 +2,18 @@ declare module 'react-frame-component' {
   import * as React from 'react';
 
   export interface FrameComponentProps
-    extends React.IframeHTMLAttributes<HTMLIFrameElement> {
+    extends React.IframeHTMLAttributes<HTMLIFrameElement>,
+      React.RefAttributes<HTMLIFrameElement> {
     head?: React.ReactNode | undefined;
     mountTarget?: string | undefined;
     initialContent?: string | undefined;
     contentDidMount?: (() => void) | undefined;
     contentDidUpdate?: (() => void) | undefined;
     children: React.ReactNode;
-    ref?: React.Ref<HTMLIFrameElement>;
   }
 
-  export default class FrameComponent extends React.Component<
-    FrameComponentProps
-  > {}
+  const FrameComponent: React.ForwardRefExoticComponent<FrameComponentProps>;
+  export default FrameComponent;
 
   export interface FrameContextProps {
     document?: HTMLDocument;


### PR DESCRIPTION
Closes #225 

This change updates the type of the default export of this library to correct match what's in the JS code.

Previously, the types indicated the default export was a class component which resulted in an invalid defintion of the `ref` prop. In reality, the default export was function component returned from `React.forwardRef`.

I've tested this change in types locally with the following snippet:

```tsx
import React from "react";
import Frame, { useFrame } from "react-frame-component";

const CodeBlockFrame: React.FC<CodeBlockFrameProps> = (props) => {
  const { theme } = useTheme();
  const cacheKey = useAlphaId();
  const iframeRef = React.useRef<HTMLIFrameElement>(null);

  if (!cacheKey) {
    return null;
  }

  return (
    <Frame
      ref={iframeRef}
      title="Live demo sandbox"
      css={frameStyle(theme, props)}
      style={initialStyles}
      initialContent={initialContent(`rl-emotion-${cacheKey}`)}
    >
      <FrameBody>{props.children}</FrameBody>
    </Frame>
  );
};
```

You can ignore a bunch of that code. The main bit was the `iframeRef` returned from `useRef` was assignable to the `Frame`'s `ref` prop.