### PR TITLE
Fix handleLoad call from setInterval

### DIFF
--- a/src/Frame.jsx
+++ b/src/Frame.jsx
@@ -95,9 +95,12 @@ export class Frame extends Component {
 
   // In certain situations on a cold cache DOMContentLoaded never gets called
   // fallback to an interval to check if that's the case
-  loadCheck = setInterval(function loadCheckCallback() {
-    this.handleLoad();
-  }, 500);
+  loadCheck = () => {
+    const self = this;
+    setInterval(() => {
+      self.handleLoad();
+    }, 500);
+  };
 
   renderFrameContents() {
     if (!this._isMounted) {

--- a/src/Frame.jsx
+++ b/src/Frame.jsx
@@ -95,12 +95,10 @@ export class Frame extends Component {
 
   // In certain situations on a cold cache DOMContentLoaded never gets called
   // fallback to an interval to check if that's the case
-  loadCheck = () => {
-    const self = this;
+  loadCheck = () =>
     setInterval(() => {
-      self.handleLoad();
+      this.handleLoad();
     }, 500);
-  };
 
   renderFrameContents() {
     if (!this._isMounted) {


### PR DESCRIPTION
Fixes #234 

The root cause is incorrect `this` context when it is invoked within the `setInterval` ([MDN doc](https://developer.mozilla.org/en-US/docs/Web/API/setInterval#the_this_problem) for reference).