### PR TITLE
fix: update FrameContextProps to use Document

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,7 @@ declare module 'react-frame-component' {
   export default FrameComponent;
 
   export interface FrameContextProps {
-    document?: HTMLDocument;
+    document?: Document;
     window?: Window;
   }
 


### PR DESCRIPTION
Looks like `HTMLDocument` is deprecated and `Document` should be used instead

<img width="833" alt="Screenshot 2023-05-22 at 3 02 11 PM" src="https://github.com/ryanseddon/react-frame-component/assets/21000200/62d8c765-8da3-4db9-b34c-4cb93b3d7d21">
