### PR TITLE
Add document.write() fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ The `mountTarget` props is a css selector (#target/.target) that specifies where
 </Frame>
 ```
 
+###### dangerouslyUseDocWrite
+`dangerouslyUseDocWrite: PropTypes.bool`
+
+Defaults to `false`
+
+The frame's initial content, as defined by the `initialContent` prop, is populated via the frame's `srcdoc` attribute by default. However, this can cause issues with some libraries such as Recaptcha and Google Maps that depend on the frame's location/origin. In these cases, setting this flag will cause `Frame` to use `document.write()` to populate the initial content. This is **unperformant and unrecommended**, but allows these libraries to be used inside a `Frame` instance.
+
 ###### contentDidMount and contentDidUpdate
 `contentDidMount:  PropTypes.func`
 `contentDidUpdate:  PropTypes.func`

--- a/src/Frame.jsx
+++ b/src/Frame.jsx
@@ -14,6 +14,7 @@ export class Frame extends Component {
     head: PropTypes.node,
     initialContent: PropTypes.string,
     mountTarget: PropTypes.string,
+    dangerouslyUseDocWrite: PropTypes.bool,
     contentDidMount: PropTypes.func,
     contentDidUpdate: PropTypes.func,
     children: PropTypes.oneOfType([
@@ -27,6 +28,7 @@ export class Frame extends Component {
     head: null,
     children: undefined,
     mountTarget: undefined,
+    dangerouslyUseDocWrite: false,
     contentDidMount: () => {},
     contentDidUpdate: () => {},
     initialContent:
@@ -126,6 +128,12 @@ export class Frame extends Component {
       </Content>
     );
 
+    if (this.props.dangerouslyUseDocWrite && doc.body.children.length < 1) {
+      doc.open('text/html', 'replace');
+      doc.write(this.props.initialContent);
+      doc.close();
+    }
+
     const mountTarget = this.getMountTarget();
 
     return [
@@ -137,12 +145,17 @@ export class Frame extends Component {
   render() {
     const props = {
       ...this.props,
-      srcDoc: this.props.initialContent,
       children: undefined // The iframe isn't ready so we drop children from props here. #12, #17
     };
+
+    if (!this.props.dangerouslyUseDocWrite) {
+      props.srcDoc = this.props.initialContent;
+    }
+
     delete props.head;
     delete props.initialContent;
     delete props.mountTarget;
+    delete props.dangerouslyUseDocWrite;
     delete props.contentDidMount;
     delete props.contentDidUpdate;
     delete props.forwardedRef;

--- a/test/Frame.spec.jsx
+++ b/test/Frame.spec.jsx
@@ -253,6 +253,27 @@ describe('The Frame Component', () => {
     );
   });
 
+  it.only('should allow setting initialContent via document.write() when required', done => {
+    div = document.body.appendChild(document.createElement('div'));
+
+    const initialContent =
+      '<!DOCTYPE html><html><head><script>console.log("foo");</script></head><body><div></div></body></html>';
+    const renderedContent =
+      '<html><head><script>console.log("foo");</script></head><body><div><div class="frame-content"></div></div></body></html>';
+    const frame = ReactDOM.render(
+      <Frame
+        dangerouslyUseDocWrite
+        initialContent={initialContent}
+        contentDidMount={() => {
+          const doc = ReactDOM.findDOMNode(frame).contentDocument;
+          expect(doc.documentElement.outerHTML).to.equal(renderedContent);
+          done();
+        }}
+      />,
+      div
+    );
+  });
+
   it('should allow setting mountTarget', done => {
     div = document.body.appendChild(document.createElement('div'));
 


### PR DESCRIPTION
As per https://github.com/ryanseddon/react-frame-component/issues/169#issuecomment-1769738677, this PR adds a new `dangerouslyUseDocWrite` prop to the `Frame` component as an "escape hatch" that allows consumers to fall back to using `document.write()` to populate the frame's initial content. This is usually not advisable, but some libraries such as Recaptcha and Google Maps will only work with certain values of the frame's location and/or origin, and the current `srcdoc` approach for initial content population is incompatible with these libraries.