### PR TITLE
Handle load on already loaded iframe document (NextJS)

### DIFF
--- a/src/Frame.jsx
+++ b/src/Frame.jsx
@@ -50,6 +50,9 @@ export class Frame extends Component {
         'DOMContentLoaded',
         this.handleLoad
       );
+      if (doc.readyState === 'complete') {
+        this.handleLoad();
+      }
     }
   }
 


### PR DESCRIPTION
Server rendered iframe not firing DOMContentLoaded event and iframe already in state 'complete'.
This fixes issue that child content not gona rendered in iframe with portal