### PR TITLE
fix: add release permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
+      packages: write
       id-token: write
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
Add missing permissions to the release workflow for GitHub Actions.