### PR TITLE
Update npm to latest for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - name: Install Dependencies
         run: npm install
 


### PR DESCRIPTION
Adds npm update step to fix 404 errors with OIDC trusted publishing. See https://github.com/community/community/discussions/173102#discussioncomment-15340466